### PR TITLE
Note on XCode for macOS users & minor edits

### DIFF
--- a/src/doc/users-guide/getting-started.md
+++ b/src/doc/users-guide/getting-started.md
@@ -23,7 +23,7 @@ OpenCilk.
 ## Using the compiler
 
 To compile a Cilk program with OpenCilk, pass the `-fopencilk` flag to Clang
-(or Clang++):
+(or Clang++).  For example:
 
 ```shell-session
 $ clang -fopencilk -O3 fib.c -o fib

--- a/src/doc/users-guide/getting-started.md
+++ b/src/doc/users-guide/getting-started.md
@@ -43,6 +43,18 @@ target-dependent compilation options. See the [Clang
 documentation](https://releases.llvm.org/12.0.0/tools/clang/docs/ClangCommandLineReference.html)
 for more information on the command-line arguments.
 
+### macOS
+
+On macOS, `clang` needs standard system libraries and headers which are provided by
+[XCode](https://developer.apple.com/support/xcode/) or the [XCode Command Line
+Tools](https://mac.install.guide/commandlinetools/index.html).  To run the
+OpenCilk compiler with those libraries and headers, invoke the `clang` binary
+with `xcrun`.  For example:
+
+```shell-session
+$ xcrun clang -fopencilk -O3 fib.c -o fib
+```
+
 ## Running the program on multiple cores
 
 The program will automatically execute in parallel, using all available cores.

--- a/src/doc/users-guide/install.md
+++ b/src/doc/users-guide/install.md
@@ -67,15 +67,15 @@ Optionally, you can select a different installation directory by passing the
 option `--prefix=/path/to/install/dir` to the script.  To see all options, pass
 the `--help` argument to the script.
 
-The OpenCilk C (or C++) compiler can be invoked from `bin/clang` (or
-`bin/clang++`) within the installation directory.
+The OpenCilk C (or C++) compiler can be invoked via `bin/clang` (or
+`bin/clang++`) from within the installation directory.
 
 #### Example
 
 The following shows the process of installing OpenCilk into a version-specific
 subdirectory within `/opt/opencilk/`.
 
-```
+```shell-session
 $ sh OpenCilk-1.1-LLVM-12.0.0-Ubuntu-20.04-x86_64.sh --prefix=/opt/opencilk
 OpenCilk Installer Version: 12.0.0, Copyright (c) OpenCilk
 This is a self-extracting archive.

--- a/src/doc/users-guide/install.md
+++ b/src/doc/users-guide/install.md
@@ -24,19 +24,22 @@ archive (`.sh`), tarball (`.tar.gz`), or Docker image.
 
 You can also [build OpenCilk from source](../build-opencilk-from-source).
 
-**Linux**
+### Linux
+ 
  - [OpenCilk-1.1-LLVM-12.0.0-Ubuntu-20.04-x86_64.sh](https://github.com/OpenCilk/opencilk-project/releases/download/opencilk%2Fv1.1/OpenCilk-1.1-LLVM-12.0.0-Ubuntu-20.04-x86_64.sh)
    (749 MB)
  - [OpenCilk-1.1-LLVM-12.0.0-Ubuntu-20.04-x86_64.tar.gz](https://github.com/OpenCilk/opencilk-project/releases/download/opencilk%2Fv1.1/OpenCilk-1.1-LLVM-12.0.0-Ubuntu-20.04-x86_64.tar.gz)
    (749 MB)
 
-**macOS**
+### macOS
+
  - [OpenCilk-1.1-LLVM-12.0.0-Darwin-arm64.sh](https://github.com/OpenCilk/opencilk-project/releases/download/opencilk%2Fv1.1/OpenCilk-1.1-LLVM-12.0.0-Darwin-arm64.sh)
    (736 MB)
  - [OpenCilk-1.1-LLVM-12.0.0-Darwin-arm64.tar.gz](https://github.com/OpenCilk/opencilk-project/releases/download/opencilk%2Fv1.1/OpenCilk-1.1-LLVM-12.0.0-Darwin-arm64.tar.gz)
    (736 MB)
 
-**Docker**
+### Docker
+
  - [docker-opencilk-v1.1.tar.gz](https://github.com/OpenCilk/opencilk-project/releases/download/opencilk%2Fv1.1/docker-opencilk-v1.1.tar.gz)
    (814 MB)
 

--- a/src/doc/users-guide/install.md
+++ b/src/doc/users-guide/install.md
@@ -38,6 +38,12 @@ You can also [build OpenCilk from source](../build-opencilk-from-source).
  - [OpenCilk-1.1-LLVM-12.0.0-Darwin-arm64.tar.gz](https://github.com/OpenCilk/opencilk-project/releases/download/opencilk%2Fv1.1/OpenCilk-1.1-LLVM-12.0.0-Darwin-arm64.tar.gz)
    (736 MB)
 
+> ***Note for macOS users:*** Unless you are using the OpenCilk Docker image,
+> you must also install [XCode](https://developer.apple.com/support/xcode/) or
+> the [XCode Command Line
+> Tools](https://mac.install.guide/commandlinetools/index.html), which provide
+> standard system libraries and header files needed by the OpenCilk compiler.
+
 ### Docker
 
  - [docker-opencilk-v1.1.tar.gz](https://github.com/OpenCilk/opencilk-project/releases/download/opencilk%2Fv1.1/docker-opencilk-v1.1.tar.gz)


### PR DESCRIPTION
- Add notes to macOS users for installing and using XCode or the XCode Command Line Tools (with instruction links).
- Use `shell-session` code style for installation example.
- Some minor edits.