### PR TITLE
Create software.md

### DIFF
--- a/src/community/software.md
+++ b/src/community/software.md
@@ -1,0 +1,40 @@
+---
+layout: layouts/page.njk
+sidebar: toc
+title: Software
+eleventyNavigation:
+  key: Software
+  parent: Community
+  order: 99
+---
+
+This page lists software contributed by the community that is related to OpenCilk, including OpenCilk-powered applications and libraries and
+miscellaneous tools to help developers write Cilk programs.
+
+### OpenCilk-powered libraries
+
+The following third-party libraries are known to work with OpenCilk out of the
+box for parallel execution.
+
+- [SG-t-SNE-Π](https://github.com/fcdimitr/sgtsnepi): Low-dimensional embedding
+  of sparse stochastic graphs.
+- [FGLT](https://github.com/ailiop/fglt): Fast graphlet transform.
+- [RecFMM](https://github.com/zhang416/recfmm): Adaptive fast multipole method.
+- [PArlayLib](https://github.com/cmuparlay/parlaylib): A toolkit for programming parallel algorithms on shared-memory multicore machines.
+
+### OpenCilk-powered applications
+
+The following third-party applications are known to work with OpenCilk.
+
+- [The Problem Based Benchmark Suite (V2)](https://cmuparlay.github.io/pbbsbench/): A collection of over 20 benchmarks defined in terms of their IO characteristics.
+- [GBBS: Graph Based Benchmark Suite](https://github.com/ParAlg/gbbs): A collection of fast parallel graph algorithms.
+- [mold](https://github.com/wheatman/mold): A port of the mold linker to OpenCilk.
+
+### Miscellaneous developer tools
+
+- [cilk-mode.el](https://github.com/ailiop/cilk-mode/): Emacs minor mode for
+  Cilk source code.
+
+### Contribute
+
+Want your OpenCilk-powered software listed here?  Contact us at [contact@opencilk.org](mailto:contact@opencilk.org).

--- a/src/community/software.md
+++ b/src/community/software.md
@@ -20,7 +20,7 @@ box for parallel execution.
   of sparse stochastic graphs.
 - [FGLT](https://github.com/ailiop/fglt): Fast graphlet transform.
 - [RecFMM](https://github.com/zhang416/recfmm): Adaptive fast multipole method.
-- [PArlayLib](https://github.com/cmuparlay/parlaylib): A toolkit for programming parallel algorithms on shared-memory multicore machines.
+- [ParlayLib](https://github.com/cmuparlay/parlaylib): A toolkit for programming parallel algorithms on shared-memory multicore machines.
 
 ### OpenCilk-powered applications
 
@@ -38,3 +38,5 @@ The following third-party applications are known to work with OpenCilk.
 ### Contribute
 
 Want your OpenCilk-powered software listed here?  Contact us at [contact@opencilk.org](mailto:contact@opencilk.org).
+
+You can find more information on contributing to OpenCilk [here](/contribute).

--- a/src/community/software.md
+++ b/src/community/software.md
@@ -35,7 +35,7 @@ The following third-party applications are known to work with OpenCilk.
 - [cilk-mode.el](https://github.com/ailiop/cilk-mode/): Emacs minor mode for
   Cilk source code.
 
-### Contribute
+## Contribute
 
 Want your OpenCilk-powered software listed here?  Contact us at [contact@opencilk.org](mailto:contact@opencilk.org).
 

--- a/src/community/software.md
+++ b/src/community/software.md
@@ -11,7 +11,7 @@ eleventyNavigation:
 This page lists software contributed by the community that is related to OpenCilk, including OpenCilk-powered applications and libraries and
 miscellaneous tools to help developers write Cilk programs.
 
-### OpenCilk-powered libraries
+## OpenCilk-powered libraries
 
 The following third-party libraries are known to work with OpenCilk out of the
 box for parallel execution.
@@ -22,7 +22,7 @@ box for parallel execution.
 - [RecFMM](https://github.com/zhang416/recfmm): Adaptive fast multipole method.
 - [ParlayLib](https://github.com/cmuparlay/parlaylib): A toolkit for programming parallel algorithms on shared-memory multicore machines.
 
-### OpenCilk-powered applications
+## OpenCilk-powered applications
 
 The following third-party applications are known to work with OpenCilk.
 
@@ -30,7 +30,7 @@ The following third-party applications are known to work with OpenCilk.
 - [GBBS: Graph Based Benchmark Suite](https://github.com/ParAlg/gbbs): A collection of fast parallel graph algorithms.
 - [mold](https://github.com/wheatman/mold): A port of the mold linker to OpenCilk.
 
-### Miscellaneous developer tools
+## Miscellaneous developer tools
 
 - [cilk-mode.el](https://github.com/ailiop/cilk-mode/): Emacs minor mode for
   Cilk source code.


### PR DESCRIPTION
Add new page for OpenCilk-related software, to hold some content originally included in /doc/users-guide/install.md.