### PR TITLE
Change Clang documentation link from 12 to 14

### DIFF
--- a/src/doc/users-guide/getting-started.md
+++ b/src/doc/users-guide/getting-started.md
@@ -43,7 +43,7 @@ The OpenCilk compiler is based on a recent stable version of the LLVM `clang`
 compiler.  It supports all compiler flags and features that LLVM `clang`
 supports, including optimization-level flags, debug-information flags, and
 target-dependent compilation options. See the [Clang
-documentation](https://releases.llvm.org/12.0.0/tools/clang/docs/ClangCommandLineReference.html)
+documentation](https://releases.llvm.org/14.0.0/tools/clang/docs/ClangCommandLineReference.html)
 for more information on the command-line arguments.
 
 ### macOS


### PR DESCRIPTION
@ailiop I am pretty sure this should be Clang v14 and not 12, right? (Guessing because my `clang -v` says version 14.0.6.)