### PR TITLE
/doc/users-guide/getting-started

### DIFF
--- a/src/doc/users-guide/getting-started.md
+++ b/src/doc/users-guide/getting-started.md
@@ -195,7 +195,7 @@ Cilksan does not currently recognize.  To work around this behavior, add the
 flag `–D_FORTIFY_SOURCE=0` when compiling:
 
 ```shell-session
-$ clang -fopencilk -fsanitize=cilk -Og -g -D_FORTIFY_SOURCE=0 nqueens.c -o nqueens
+$ xcrun clang -fopencilk -fsanitize=cilk -Og -g -D_FORTIFY_SOURCE=0 nqueens.c -o nqueens
 ```
 {% endalert %}
 

--- a/src/doc/users-guide/getting-started.md
+++ b/src/doc/users-guide/getting-started.md
@@ -69,8 +69,8 @@ $ cd tutorial
 
 ## Using the compiler
 
-To compile a Cilk program with OpenCilk, pass the `-fopencilk` flag to Clang
-(or Clang++).  For example:
+To compile a Cilk program with OpenCilk, pass the `-fopencilk` flag to the
+compiler.  For example:
 
 ```shell-session
 $ clang -fopencilk -O3 fib.c -o fib
@@ -93,24 +93,29 @@ Former users of Intel Cilk Plus with GCC: Do **not** include the
 
 {% endalert %}
 
-The OpenCilk compiler is based on a recent stable version of the LLVM `clang`
-compiler.  It supports all compiler flags and features that LLVM `clang`
-supports, including optimization-level flags, debug-information flags, and
-target-dependent compilation options. See the [Clang
-documentation](https://releases.llvm.org/14.0.0/tools/clang/docs/ClangCommandLineReference.html)
-for more information on the command-line arguments.
+{% alert "info" %}
 
-### macOS
-
-On macOS, `clang` needs standard system libraries and headers which are provided by
+***macOS users:*** On macOS, `clang` needs the standard system libraries and
+headers that are provided by
 [XCode](https://developer.apple.com/support/xcode/) or the [XCode Command Line
 Tools](https://mac.install.guide/commandlinetools/index.html).  To run the
-OpenCilk compiler with those libraries and headers, invoke the `clang` binary
-with `xcrun`.  For example:
+OpenCilk compiler with those libraries and headers, invoke `clang` with
+`xcrun`.  For example:
 
 ```shell-session
 $ xcrun clang -fopencilk -O3 fib.c -o fib
 ```
+
+{% endalert %}
+
+The OpenCilk compiler is based on a recent stable version of the LLVM `clang`
+compiler.  In addition to OpenCilk-specific options, the OpenCilk compiler
+supports all flags and features of LLVM `clang`, including optimization-level
+flags, debug-information flags, and target-dependent compilation options.  See
+the [LLVM Clang
+documentation](https://releases.llvm.org/12.0.0/tools/clang/docs/ClangCommandLineReference.html)
+for more information on the command-line arguments.
+
 
 ## Running the program on multiple cores
 

--- a/src/doc/users-guide/getting-started.md
+++ b/src/doc/users-guide/getting-started.md
@@ -3,8 +3,62 @@ title: Getting started
 eleventyNavigation:
   order: -2
 ---
-First, [install OpenCilk](/doc/users-guide/install).  Then, download the
-[tutorial](https://github.com/OpenCilk/tutorial) code examples and enter the
+This guide will overview the components of OpenCilk and walk you through the
+basic steps of building, running, and testing a Cilk program with OpenCilk.
+
+
+## Prerequisites
+
+### OpenCilk installation
+
+See the [install page](/doc/users-guide/install) for detailed instructions on
+installing the latest version of OpenCilk.
+
+This guide assumes that OpenCilk is installed within `/opt/opencilk/` and that
+the OpenCilk C compiler can be invoked from the terminal as `clang`.
+
+{% alert "primary" %}
+
+***Example:*** First, download the precompiled [OpenCilk shell
+archive](/doc/users-guide/install/#installing-using-a-shell-archive) for your
+system.  Then, assuming you are on Ubuntu 20.04, install OpenCilk with the
+following command:
+
+```shell-session
+$ mkdir -p /opt/opencilk
+$ sh OpenCilk-2.0.0-x86_64-Linux-Ubuntu-20.04.sh --prefix=/opt/opencilk --exclude-subdir
+```
+
+Finally, set `clang` and `clang++` to point to the OpenCilk C and C++
+compilers.  This can be achieved in numerous ways, such as by setting your
+`PATH` environment variable to look in `/opt/opencilk/bin/`, or by installing
+system-wide symbolic links as:
+
+```shell-session
+$ sudo ln -s /opt/opencilk/bin/clang /usr/local/bin/clang
+$ sudo ln -s /opt/opencilk/bin/clang++ /usr/local/bin/clang++
+```
+
+You can verify that `clang` (similarly for `clang++`) points to the OpenCilk
+compiler with the following command:
+
+```shell-session
+$ clang --version
+clang version 14.0.6 (https://github.com/OpenCilk/opencilk-project fc90ded2b090672f84c58d12d8d85cd999eb6c1a)
+Target: x86_64-unknown-linux-gnu
+Thread model: posix
+InstalledDir: /usr/local/bin
+```
+
+The installation and setup process is analogous for macOS and other Linux
+systems.
+
+{% endalert %}
+
+### Example Cilk programs
+
+Download the example Cilk codes in the [OpenCilk
+tutorial](https://github.com/OpenCilk/tutorial) GitHub repository and enter the
 cloned directory:
 
 ```shell-session
@@ -12,16 +66,6 @@ $ git clone https://github.com/OpenCilk/tutorial
 $ cd tutorial
 ```
 
-Let us walk through the steps of building, running, and testing a program with
-OpenCilk.
-
-{% alert "info" %}
-
-***Note:*** The rest of this guide assumes that OpenCilk is installed within
-`/opt/opencilk/` and that `clang` points to the OpenCilk C compiler at
-`/opt/opencilk/bin/clang`.
-
-{% endalert %}
 
 ## Using the compiler
 

--- a/src/doc/users-guide/getting-started.md
+++ b/src/doc/users-guide/getting-started.md
@@ -253,7 +253,7 @@ output the results as a CSV table (`out.csv`) and as plots in a PDF document
 (`plot.pdf`):
 
 ```shell-session
-$ python3 /opt/opencilk/share/Cilkscale_vis/cilkscale.py -c qsort -b qsort-bench --args 10000000
+$ python3 /opt/opencilk/share/Cilkscale_vis/cilkscale.py -c ./qsort -b ./qsort-bench --args 10000000
 Namespace(args=['10000000'], cilkscale='./qsort', cilkscale_benchmark='./qsort_bench',
 cpu_counts=None, output_csv='out.csv', output_plot='plot.pdf', rows_to_plot='all')
 

--- a/src/doc/users-guide/getting-started.md
+++ b/src/doc/users-guide/getting-started.md
@@ -1,11 +1,9 @@
 ---
 title: Getting started
+tagline: This guide overviews the components of OpenCilk and walks through the basic steps of building, running, and testing a Cilk program with OpenCilk.
 eleventyNavigation:
   order: -2
 ---
-This guide will overview the components of OpenCilk and walk you through the
-basic steps of building, running, and testing a Cilk program with OpenCilk.
-
 
 ## Prerequisites
 
@@ -13,47 +11,9 @@ basic steps of building, running, and testing a Cilk program with OpenCilk.
 
 See the [install page](/doc/users-guide/install) for detailed instructions on
 installing the latest version of OpenCilk.
-
-This guide assumes that OpenCilk is installed within `/opt/opencilk/` and that
-the OpenCilk C compiler can be invoked from the terminal as `clang`.
-
-{% alert "primary" %}
-
-***Example:*** First, download the precompiled [OpenCilk shell
-archive](/doc/users-guide/install/#installing-using-a-shell-archive) for your
-system.  Then, assuming you are on Ubuntu 20.04, install OpenCilk with the
-following command:
-
-```shell-session
-$ mkdir -p /opt/opencilk
-$ sh OpenCilk-2.0.0-x86_64-Linux-Ubuntu-20.04.sh --prefix=/opt/opencilk --exclude-subdir
-```
-
-Finally, set `clang` and `clang++` to point to the OpenCilk C and C++
-compilers.  This can be achieved in numerous ways, such as by setting your
-`PATH` environment variable to look in `/opt/opencilk/bin/`, or by installing
-system-wide symbolic links as:
-
-```shell-session
-$ sudo ln -s /opt/opencilk/bin/clang /usr/local/bin/clang
-$ sudo ln -s /opt/opencilk/bin/clang++ /usr/local/bin/clang++
-```
-
-You can verify that `clang` (similarly for `clang++`) points to the OpenCilk
-compiler with the following command:
-
-```shell-session
-$ clang --version
-clang version 14.0.6 (https://github.com/OpenCilk/opencilk-project fc90ded2b090672f84c58d12d8d85cd999eb6c1a)
-Target: x86_64-unknown-linux-gnu
-Thread model: posix
-InstalledDir: /usr/local/bin
-```
-
-The installation and setup process is analogous for macOS and other Linux
-systems.
-
-{% endalert %}
+We assume you have installed OpenCilk as shown in [this example](/doc/users-guide/install/#example),
+so that the OpenCilk files are in `/opt/opencilk/`,
+and the OpenCilk C/C++ compiler can be invoked from the terminal as `clang` or `clang++`.
 
 ### Example Cilk programs
 

--- a/src/doc/users-guide/getting-started.md
+++ b/src/doc/users-guide/getting-started.md
@@ -114,11 +114,14 @@ $ xcrun clang -fopencilk -O3 fib.c -o fib
 
 ## Running the program on multiple cores
 
-The program will automatically execute in parallel, using all available cores.
+A Cilk program compiled with OpenCilk will automatically execute in parallel,
+using all available cores.  For example, on a laptop with an 8-core Intel Core
+i7-10875H CPU:
 
 ```shell-session
-$ ./fib 35
-fib(35) = 9227465
+$ ./fib 40 
+fib(40) = 102334155
+Time(fib) = 0.368499700 sec
 ```
 
 To explicitly set the number of parallel Cilk workers for a program execution,
@@ -126,8 +129,9 @@ set the `CILK_NWORKERS` environment variable.  For example, to execute `fib`
 using only 2 parallel cores:
 
 ```shell-session
-$ CILK_NWORKERS=2 ./fib 35
-fib(35) = 9227465
+$ CILK_NWORKERS=2 ./fib 40
+fib(40) = 102334155
+Time(fib) = 1.459649400 sec
 ```
 
 ## Using Cilksan

--- a/src/doc/users-guide/getting-started.md
+++ b/src/doc/users-guide/getting-started.md
@@ -73,7 +73,7 @@ compiler.  In addition to OpenCilk-specific options, the OpenCilk compiler
 supports all flags and features of LLVM `clang`, including optimization-level
 flags, debug-information flags, and target-dependent compilation options.  See
 the [LLVM Clang
-documentation](https://releases.llvm.org/12.0.0/tools/clang/docs/ClangCommandLineReference.html)
+documentation](https://releases.llvm.org/14.0.0/tools/clang/docs/ClangCommandLineReference.html)
 for more information on the command-line arguments.
 
 

--- a/src/doc/users-guide/getting-started.md
+++ b/src/doc/users-guide/getting-started.md
@@ -237,55 +237,32 @@ tag,work (seconds),span (seconds),parallelism,burdened_span (seconds),burdened_p
 ,13.9352,0.177858,78.35,0.178218,78.1917
 ```
 
-### Analyzing a region
+{% alert "info" %}
 
-By default, Cilkscale will only analyze whole-program execution.  To analyze
-specific regions of a program, annotate the code accordingly using the
-Cilkscale API. 
+***Work-span analysis of specific program regions:*** By default, Cilkscale
+will only analyze whole-program execution.  To analyze specific regions of your
+Cilk program, use the [Cilkscale work-span API](dead-link).
 
-For example, to measure the work and span of the core function `sample_qsort`
-in the tutorial `qsort.c` code:
+<br/>
+{% alert "primary" %}
 
-```c
-…
-#include <cilk/cilkscale.h>
-…
-int main(int argc, char **argv) {
-  // …
-  wsp_t start, end;
-  start = wsp_getworkspan();
-  sample_qsort(a, a + n); /* <-- analyze this */
-  end = wsp_getworkspan(); 
-  // …
-  wsp_dump(wsp_sub(end, start), "sample_qsort");
-  // …
-}
-```
+***Example:*** The tutorial program `qsort_wsp.c` shows how to modify the code
+of `qsort.c` to measure the work and span of the core function
+`sample_qsort()`.  Compiling `qsort_wsp.c` with Cilkscale and running the
+instrumented binary will output an additional row in Cilkscale's CSV table with
+the analysis results for `sample_qsort()`.
 
-Then, recompile with Cilkscale and rerun:
+{% endalert %}
 
-```shell-session
-$ clang -fopencilk -fcilktool=cilkscale -O3 qsort.c -o qsort
-$ ./qsort 10000000
-Sorting 10000000 integers
-All sorts succeeded
-tag,work (seconds),span (seconds),parallelism,burdened_span (seconds),burdened_parallelism
-sample_qsort,14.3595,0.13184,108.916,0.132084,108.715
-,14.412,0.184341,78.181,0.184585,78.0777
-```
-
-Every analyzed region appears as a separate row in the Cilkscale CSV output,
-tagged with the string that was passed in the corresponding call to `wsp_dump()`.
+{% endalert %}
 
 ### Scalability benchmarking and visualization
 
-Cilkscale can also be used to benchmark and plot the execution time of your
-program (and each analyzed region) on different numbers of processors.
+Cilkscale also provides facilities to benchmark and plot the execution time of
+your program (and each analyzed region) on different numbers of processors.
 
-First, build your program twice,
-
-* once with `-fcilktool=cilkscale`, and
-* once with `-fcilktool=cilkscale-benchmark`:
+First, build your program twice, once with `-fcilktool=cilkscale` and once with
+`-fcilktool=cilkscale-benchmark`:
 
 ```shell-session
 $ clang -fopencilk -fcilktool=cilkscale -O3 qsort.c -o qsort

--- a/src/doc/users-guide/getting-started.md
+++ b/src/doc/users-guide/getting-started.md
@@ -16,9 +16,11 @@ Let us walk through the steps of building, running, and testing a program with
 OpenCilk.
 
 {% alert "info" %}
+
 ***Note:*** The rest of this guide assumes that OpenCilk is installed within
 `/opt/opencilk/` and that `clang` points to the OpenCilk C compiler at
 `/opt/opencilk/bin/clang`.
+
 {% endalert %}
 
 ## Using the compiler
@@ -31,12 +33,20 @@ $ clang -fopencilk -O3 fib.c -o fib
 ```
 
 {% alert "info" %}
-***Note:*** Pass the `-fopencilk` flag to the compiler both when compiling
-and linking the Cilk program.  During compilation, the flag ensures that the
-Cilk keywords are recognized and compiled.  During linking, the flag links
-ensures the program is properly linked with the OpenCilk runtime library.
-(*Former users of Intel Cilk Plus with GCC:* make sure you do *not* include
-the `-lcilkrts` flag when linking.)
+
+***Note:*** Pass the `-fopencilk` flag to the compiler both when compiling and
+linking the Cilk program.  During compilation, the flag ensures that the Cilk
+keywords are recognized and compiled.  During linking, it ensures the program
+is properly linked with the OpenCilk runtime library.
+
+<br/>
+{% alert "danger" %}
+
+Former users of Intel Cilk Plus with GCC: Do **not** include the
+`-lcilkrts` flag when linking.
+
+{% endalert %}
+
 {% endalert %}
 
 The OpenCilk compiler is based on a recent stable version of the LLVM `clang`
@@ -68,7 +78,8 @@ fib(35) = 9227465
 ```
 
 To explicitly set the number of parallel Cilk workers for a program execution,
-set the `CILK_NWORKERS` environment variable.  For example:
+set the `CILK_NWORKERS` environment variable.  For example, to execute `fib`
+using only 2 parallel cores:
 
 ```shell-session
 $ CILK_NWORKERS=2 ./fib 35
@@ -235,17 +246,11 @@ $ clang -fopencilk -fcilktool=cilkscale-benchmark -O3 qsort.c -o qsort-bench
 
 Then, run the program with the Cilkscale benchmarking and visualizer Python
 script, which is found at `share/Cilkscale_vis/cilkscale.py` within the
-OpenCilk installation directory: 
-
-```shell-session
-$ python3 /opt/opencilk/share/Cilkscale_vis/cilkscale.py \
-    -c qsort -b qsort-bench --args 10000000
-```
-
-This will first measure work, span, and parallelism; run the program with $1$,
-$2$, ..., $P$ Cilk workers (where $P$ is the number of available physical
-cores) and time the execution; and output the results as a CSV table (`out.csv`) and as
-plots in a PDF document (`plot.pdf`):
+OpenCilk installation directory.  The following will first measure work, span,
+and parallelism; run the program with $1$, $2$, ..., $P$ Cilk workers (where
+$P$ is the number of available physical cores) and time the execution; and
+output the results as a CSV table (`out.csv`) and as plots in a PDF document
+(`plot.pdf`):
 
 ```shell-session
 $ python3 /opt/opencilk/share/Cilkscale_vis/cilkscale.py -c qsort -b qsort-bench --args 10000000

--- a/src/doc/users-guide/getting-started.md
+++ b/src/doc/users-guide/getting-started.md
@@ -199,12 +199,14 @@ $ xcrun clang -fopencilk -fsanitize=cilk -Og -g -D_FORTIFY_SOURCE=0 nqueens.c -o
 ```
 {% endalert %}
 
+
 ## Using Cilkscale
 
-Use the OpenCilk Cilkscale scalability analyzer and benchmarking script to
-measure the [work,
-span, and parallelism](../../../posts/2022-05-20-what-the-is-parallelism-anyhow/ "What the $#@! is parallelism, anyhow?") of your Cilk program, and to
-benchmark parallel speedup on different numbers of cores.
+Use the OpenCilk [Cilkscale scalability analyzer](dead-link) script to measure
+the [work, span, and
+parallelism](../../../posts/2022-05-20-what-the-is-parallelism-anyhow/ "What
+the \$#@! is parallelism, anyhow?") of your Cilk program, and to benchmark
+parallel its speedup on different numbers of cores.
 
 To measure work and span with Cilkscale, add the `-fcilktool=cilkscale`
 flag during compilation and linking:
@@ -222,7 +224,7 @@ $ ./qsort 10000000
 Sorting 10000000 integers
 All sorts succeeded
 tag,work (seconds),span (seconds),parallelism,burdened_span (seconds),burdened_parallelism
-,14.511,0.191245,75.8764,0.191514,75.7699
+,11.9831,0.167725,71.4447,0.168013,71.3225
 ```
 
 To output the Cilkscale measurements to a file, set the `CILKSCALE_OUT`
@@ -234,7 +236,7 @@ Sorting 10000000 integers
 All sorts succeeded
 $ cat qsort_workspan.csv
 tag,work (seconds),span (seconds),parallelism,burdened_span (seconds),burdened_parallelism
-,13.9352,0.177858,78.35,0.178218,78.1917
+,12.3098,0.166994,73.7141,0.167288,73.5847
 ```
 
 {% alert "info" %}
@@ -265,46 +267,47 @@ First, build your program twice, once with `-fcilktool=cilkscale` and once with
 `-fcilktool=cilkscale-benchmark`:
 
 ```shell-session
-$ clang -fopencilk -fcilktool=cilkscale -O3 qsort.c -o qsort
-$ clang -fopencilk -fcilktool=cilkscale-benchmark -O3 qsort.c -o qsort-bench
+$ clang -fopencilk -fcilktool=cilkscale -O3 qsort_wsp.c -o qsort_wsp
+$ clang -fopencilk -fcilktool=cilkscale-benchmark -O3 qsort_wsp.c -o qsort_wsp_bench
 ```
 
 Then, run the program with the Cilkscale benchmarking and visualizer Python
 script, which is found at `share/Cilkscale_vis/cilkscale.py` within the
-OpenCilk installation directory.  The following will first measure work, span,
-and parallelism; run the program with $1$, $2$, ..., $P$ Cilk workers (where
-$P$ is the number of available physical cores) and time the execution; and
-output the results as a CSV table (`out.csv`) and as plots in a PDF document
-(`plot.pdf`):
+OpenCilk installation directory.  For example:
 
 ```shell-session
-$ python3 /opt/opencilk/share/Cilkscale_vis/cilkscale.py -c ./qsort -b ./qsort-bench --args 10000000
-Namespace(args=['10000000'], cilkscale='./qsort', cilkscale_benchmark='./qsort_bench',
+$ python3 /opt/opencilk/share/Cilkscale_vis/cilkscale.py -c ./qsort_wsp -b ./qsort_wsp_bench --args 10000000
+Namespace(args=['10000000'], cilkscale='./qsort_wsp', cilkscale_benchmark='./qsort_wsp_bench',
 cpu_counts=None, output_csv='out.csv', output_plot='plot.pdf', rows_to_plot='all')
 
->> STDOUT (./qsort 10000000)
+>> STDOUT (./qsort_wsp 10000000)
 Sorting 10000000 integers
 All sorts succeeded
 << END STDOUT
 
->> STDERR (./qsort 10000000)
+>> STDERR (./qsort_wsp 10000000)
 << END STDERR
 
 INFO:runner:Generating scalability data for 8 cpus.
-INFO:runner:CILK_NWORKERS=1 taskset -c 0 ./qsort_bench 10000000
-INFO:runner:CILK_NWORKERS=2 taskset -c 0,2 ./qsort_bench 10000000
-INFO:runner:CILK_NWORKERS=3 taskset -c 0,2,4 ./qsort_bench 10000000
-INFO:runner:CILK_NWORKERS=4 taskset -c 0,2,4,6 ./qsort_bench 10000000
-INFO:runner:CILK_NWORKERS=5 taskset -c 0,2,4,6,8 ./qsort_bench 10000000
-INFO:runner:CILK_NWORKERS=6 taskset -c 0,2,4,6,8,10 ./qsort_bench 10000000
-INFO:runner:CILK_NWORKERS=7 taskset -c 0,2,4,6,8,10,12 ./qsort_bench 10000000
-INFO:runner:CILK_NWORKERS=8 taskset -c 0,2,4,6,8,10,12,14 ./qsort_bench 10000000
+INFO:runner:CILK_NWORKERS=1 taskset -c 0 ./qsort_wsp_bench 10000000
+INFO:runner:CILK_NWORKERS=2 taskset -c 0,2 ./qsort_wsp_bench 10000000
+INFO:runner:CILK_NWORKERS=3 taskset -c 0,2,4 ./qsort_wsp_bench 10000000
+INFO:runner:CILK_NWORKERS=4 taskset -c 0,2,4,6 ./qsort_wsp_bench 10000000
+INFO:runner:CILK_NWORKERS=5 taskset -c 0,2,4,6,8 ./qsort_wsp_bench 10000000
+INFO:runner:CILK_NWORKERS=6 taskset -c 0,2,4,6,8,10 ./qsort_wsp_bench 10000000
+INFO:runner:CILK_NWORKERS=7 taskset -c 0,2,4,6,8,10,12 ./qsort_wsp_bench 10000000
+INFO:runner:CILK_NWORKERS=8 taskset -c 0,2,4,6,8,10,12,14 ./qsort_wsp_bench 10000000
 INFO:plotter:Generating plot
 ```
 
-To see all options of the Cilkscale `cilkscale.py` script, pass it the `--help`
-argument:
+Running the `cilkscale.py` script as above does the following:
 
-```shell-session
-$ python3 /opt/opencilk/share/Cilkscale_vis/cilkscale.py --help
-```
+1. Measures the work, span, and parallelism of `qsort_wsp` with argument
+   `10000000`.
+2. Runs and times the program with $1$, $2$, ..., $P$ parallel Cilk workers,
+   where $P$ is the number of available physical cores (in this case, $P = 8$)
+3. Outputs the analysis and benchmarking results as a CSV table (`out.csv`) and
+   as plots in a PDF document (`plot.pdf`).
+
+For more information on the Cilkscale scalability analysis and visualization
+script, see the [Cilkscale documentation page](dead-link).

--- a/src/doc/users-guide/getting-started.md
+++ b/src/doc/users-guide/getting-started.md
@@ -134,13 +134,14 @@ fib(40) = 102334155
 Time(fib) = 1.459649400 sec
 ```
 
+
 ## Using Cilksan
 
-Use the OpenCilk Cilksan race detector to verify that your parallel Cilk
-program is deterministic.  Cilksan instruments a program to detect determinacy
-race bugs at runtime.  It is guaranteed to find any and all determinacy races
-that arise in a given program execution.  If there are no races, Cilksan will
-report that the execution was race-free.
+Use the OpenCilk [Cilksan race detector](dead-link) to verify that your
+parallel Cilk program is deterministic.  Cilksan instruments a program to
+detect [determinacy race bugs](dead-link) at runtime.  Cilksan is guaranteed to
+find any and all determinacy races that arise in a given program execution.  If
+there are no races, Cilksan will report that the execution was race-free.
 
 To check for determinacy races with Cilksan, add the `-fsanitize=cilk` flag
 during compilation and linking.  We also recommend the `-Og -g` flags for
@@ -190,7 +191,7 @@ is expected to run up to several times slower than its non-instrumented serial
 counterpart.
 
 {% alert "info" %}
-***Note:*** On macOS, the compiled `nqueens.c` binary uses builtins that
+***macOS users:*** On macOS, the compiled `nqueens.c` binary uses builtins that
 Cilksan does not currently recognize.  To work around this behavior, add the
 flag `–D_FORTIFY_SOURCE=0` when compiling:
 


### PR DESCRIPTION
This PR is meant to address current (and future) problems tracked in issue #59.

- [x] Fix relative paths to `qsort` and `qsort_bench` in the Cilkscale visualizer example.
- [ ] Consistent default installation path between the Install and Getting Started pages.
- [x] Add timing information to `fib` execution with many or 2 workers.
- [ ] Link to different user's guide pages for Cilksan and Cilkscale.
- [x] Possibly remove the Cilkscale visualizer example.