### PR TITLE
add danger shortcode

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -129,6 +129,14 @@ module.exports = function(eleventyConfig) {
   markdownLibrary.render(markdownString)
   );
 
+  // Shortcodes for Bootstrap fire icon
+	eleventyConfig.addShortcode(
+    "danger",
+    function() { return `<svg xmlns="http://www.w3.org/2000/svg" width="1.2em" height="1.2em" color="var(--tangelo)" fill="currentColor" class="bi bi-fire" viewBox="0 0 16 16">
+    <path d="M8 16c3.314 0 6-2 6-5.5 0-1.5-.5-4-2.5-6 .25 1.5-1.25 2-1.25 2C11 4 9 .5 6 0c.357 2 .5 4-2 6-1.25 1-2 2.729-2 4.5C2 14 4.686 16 8 16Zm0-1c-1.657 0-3-1-3-2.75 0-.75.25-2 1.25-3C6.125 10 7 10.5 7 10.5c-.375-1.25.5-3.25 2-3.5-.179 1-.25 2 1 3 .625.5 1 1.364 1 2.25C11 14 9.657 15 8 15Z"/>
+  </svg> <span style="color:var(--tangelo)">Use responsibly:</span>` }
+  );
+
   // Shortcodes for Bootstrap 5 images
 	eleventyConfig.addShortcode(
     "img",


### PR DESCRIPTION
so people can type `{% danger %}` and get a fire icon with a warning to use the following information responsibly.