### PR TITLE
Draft articles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 _site/
 _tmp/
 .DS_Store
+.env
 node_modules/
 .vscode/
 *git/

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@11ty/eleventy": "^1.0.0",
     "@11ty/eleventy-navigation": "^0.3.2",
     "@11ty/eleventy-plugin-rss": "^1.1.2",
+    "dotenv": "^16.0.2",
     "eleventy-plugin-toc": "^1.1.5",
     "js-yaml": "^4.1.0",
     "luxon": "^2.3.1",

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -1,4 +1,4 @@
-{% if permalink %}
+{% if permalink !== false %}
 <html lang="{{ site.lang}}">
   {% include 'partials/header.njk' %}
   <body class="thumb d-flex flex-column vh-100">

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -1,3 +1,4 @@
+{% if permalink %}
 <html lang="{{ site.lang}}">
   {% include 'partials/header.njk' %}
   <body class="thumb d-flex flex-column vh-100">
@@ -92,3 +93,4 @@
     </div>
   </body>
 </html>
+{% endif %}

--- a/src/doc/doc.11tydata.js
+++ b/src/doc/doc.11tydata.js
@@ -1,9 +1,54 @@
-module.exports = {
-    eleventyComputed: {
+require('dotenv').config();
+
+const isDevEnv = process.env.ELEVENTY_ENV === 'development';
+const todaysDate = new Date();
+
+function showDraft(data) {
+	const isDraft = 'draft' in data && data.draft !== false;
+	const isFutureDate = data.page.date > todaysDate;
+	return isDevEnv || (!isDraft && !isFutureDate);
+}
+
+module.exports = function() {
+	return {
+		eleventyComputed: {
+			eleventyExcludeFromCollections: function(data) {
+				if(showDraft(data)) {
+					return data.eleventyExcludeFromCollections;
+				}
+				else {
+					return true;
+				}
+			},
+			permalink: function(data) {
+				if(showDraft(data)) {
+					return data.permalink
+				}
+				else {
+					return false;
+				}
+			},
       eleventyNavigation: {
-        key: data => data.title
+        key: function(data) {   
+          if(showDraft(data)) {
+            return data.title
+          }
+          else {
+            return false;
+          }
+        }
       },
-      sidebar: 'toc',
-      background: 'bg-white'
-    }
-  };
+      sidebar: function(data) {
+        return 'toc';
+      },
+      background: function(data) {
+				if(('draft' in data && data.draft !== false) || (data.page.date > todaysDate)) {
+					return 'text-white bg-info'
+				}
+				else {
+					return 'bg-white';
+        }
+      }
+		}
+	}
+}

--- a/src/webdev/webdev.11tydata.js
+++ b/src/webdev/webdev.11tydata.js
@@ -1,0 +1,26 @@
+require('dotenv').config();
+
+const isDevEnv = process.env.ELEVENTY_ENV === 'development';
+
+module.exports = function() {
+	return {
+		eleventyComputed: {
+			eleventyExcludeFromCollections: function(data) {
+				if(isDevEnv) {
+					return data.eleventyExcludeFromCollections;
+				}
+				else {
+					return true;
+				}
+			},
+			permalink: function(data) {
+				if(!isDevEnv) {
+					return false;
+				}
+				else {
+					return data.page.filePathStem.replace('webdev/', '/') + '/';
+				}
+			}
+		}
+	}
+}

--- a/src/webdev/webdev.json
+++ b/src/webdev/webdev.json
@@ -1,0 +1,7 @@
+{
+    "layout": "layouts/page.njk",
+    "stylesheet": "users-guide.css",
+    "sidebar": "toc",
+    "background": "text-white bg-info",
+    "tags": "webdev"
+}

--- a/src/webdev/webdev.md
+++ b/src/webdev/webdev.md
@@ -1,0 +1,16 @@
+---
+title: Webdev
+---
+
+## Web development
+
+Files in the `/src/webdev/` folder will be ignored in production and compiled only in development environments.
+You can set your environment as development with the file `/.env`:
+
+```bash
+ELEVENTY_ENV=development
+```
+
+You can also put `draft: true` into the front matter of any article in `/src/doc/`, and it will be ignored in production and compiled only in development environments. 
+
+The alternative color scheme seen here indicates that the page is `draft` and does not appear in production environments.


### PR DESCRIPTION
A change intended to provide a place in the website for internal diagnostic scripts that we want to compile with Eleventy, as described in #153.

Allow content to be noted as `draft: true` in which case it does not compile unless the host system has `/.env` with 

```
ELEVENTY_ENV=development
```

There is also a `/src/webdev/` folder. Any content in this folder is treated as draft.