### PR TITLE
UC Davis EEC 289Q

### DIFF
--- a/src/community/teach performance.md
+++ b/src/community/teach performance.md
@@ -13,12 +13,14 @@ OpenCilk enables you to teach principles of multicore computing using a state-of
 
 To help you develop your own course or module on performance engineering, we are compiling a list of relevant classes and workshops with materials that you can adapt. Each listing includes links to basic materials (e.g., lecture PDFs). Additional materials (e.g., editable slide decks, and solutions for homeworks and quizzes) are often also available, as detailed below, when you [join the OpenCilk community](../join-us/). Do you have your own class or module to add to our list? Please [let us know](/contribute/contact/).
 
-Click on the list below to jump ahead.
+{% alert "hint", "Click on a link below to jump to that section:" %}
+
 - Performance engineering of software systems
-  * [MIT 6.106](#MIT-6-106)
-  * [UC Davis EEC 289Q]
+  * [MIT 6.106](#mit-6.106)
+  * [UC Davis EEC 289Q](#uc-davis-eec-289q)
 - [Modern algorithms workshop: parallel algorithms](#modern-algorithms-workshop:-parallel-algorithms)
 
+{% endalert %}
 
 
 ## Performance engineering of software systems
@@ -64,7 +66,9 @@ Recent projects have included rotating an image, parallelization of a physical s
 
 ### UC Davis EEC 289Q
 
-John Owens adapted the course at MIT to create _Performance Engineering of Software Systems_ at UC Davis.
+John Owens adapted [MIT 6.106](#mit-6.106) to create _Performance Engineering of Software Systems_ at UC Davis.
+
+#### Lectures
 
 1. Intro and Matrix Multiplication ([PDF](https://ucdavis.box.com/s/lqbbzplf7cjo1dnxi8hon2pkjigest7n))
 2. Bentley Rules for Optimizing Work ([PDF](https://ucdavis.box.com/s/7asxi08fobekk6e1pkoo5r7zuyjrktrw))
@@ -89,16 +93,17 @@ John Owens adapted the course at MIT to create _Performance Engineering of Softw
 
 ## Modern algorithms workshop: parallel algorithms
 
-Originally created as a single full-day class, this workshop includes an introduction and 8 separate modules listed below.
+Originally created in 2018 as a single full-day class, this workshop includes an introduction and 8 separate modules listed below.
 
-- Cilk model
-- Detecting nondeterminism
-- What Is parallelism?
-- Scheduling theory primer
-- Analysis of parallel loops
-- Case study: matrix multiplication
-- Case study: Jaccard similarity
-- Post-Moore software
+- Introduction ([PDF](https://ucdavis.box.com/s/8fhamacjnflkrlf8zfpkd2w6k8y9nh1n))
+- Cilk model ([PDF](https://ucdavis.box.com/s/dpth16i82wfj1hos846id9jlrlyghiks))
+- Detecting nondeterminism ([PDF](https://ucdavis.box.com/s/wp28q6ixdg9awsm5ffk7aee7py6zzl1d))
+- What Is parallelism? ([PDF](https://ucdavis.box.com/s/zjq7henchsbtxss1piz48qa22p0cvtkr))
+- Scheduling theory primer ([PDF](https://ucdavis.box.com/s/29jdmgjamnl1oa1umswvitx2i11gxn0p))
+- Analysis of parallel loops ([PDF](https://ucdavis.box.com/s/zja591gt7riw8fj3rv367jzx8odbxeag))
+- Case study: matrix multiplication ([PDF](https://ucdavis.box.com/s/v6iydl9hgk8evewihjngyd6i8fkvq95i))
+- Case study: Jaccard similarity ([PDF](https://ucdavis.box.com/s/1dtmh0m6w080f4tcnial1qdfgla73udg))
+- Post-Moore software ([PDF](https://ucdavis.box.com/s/35umq7ysmjjl1pq4u39zf7nhrlpsb43x))
 
 [Join the OpenCilk community](../join-us/) for access to editable slide decks.
 

--- a/src/community/teach performance.md
+++ b/src/community/teach performance.md
@@ -11,15 +11,21 @@ OpenCilk enables you to teach principles of multicore computing using a state-of
 
 ## List of classes and workshops
 
-To help you develop your own course or module on performance engineering, we are compiling a list of relevant classes and workshops with materials that you can adapt. Do you have your own class or module to add to our list? Please [let us know](/contribute/contact/).
-- [Performance engineering of software systems](#performance-engineering-of-software-systems)
+To help you develop your own course or module on performance engineering, we are compiling a list of relevant classes and workshops with materials that you can adapt. Each listing includes links to basic materials (e.g., lecture PDFs). Additional materials (e.g., editable slide decks, and solutions for homeworks and quizzes) are often also available, as detailed below, when you [join the OpenCilk community](../join-us/). Do you have your own class or module to add to our list? Please [let us know](/contribute/contact/).
+
+Click on the list below to jump ahead.
+- Performance engineering of software systems
+  * [MIT 6.106](#MIT-6-106)
+  * [UC Davis EEC 289Q]
 - [Modern algorithms workshop: parallel algorithms](#modern-algorithms-workshop:-parallel-algorithms)
 
-Each listing includes links to basic materials (e.g., lecture PDFs). Additional materials (e.g., editable slide decks, and solutions for homeworks and quizzes) are often also available, as detailed below, when you [join the OpenCilk community](../join-us/).
+
 
 ## Performance engineering of software systems
 
-At MIT, _Performance Engineering of Software Systems_ is an upper-division undergraduate course with prereqs of introductory computer architecture, algorithms, and programming courses. Other faculty have adapted this material as an introductory graduate course. The class uses the C language with OpenCilk task-parallel extensions. Materials from Fall 2018 are available on [MIT Open CourseWare](https://ocw.mit.edu/courses/6-172-performance-engineering-of-software-systems-fall-2018/), which includes 23 lectures (listed below), [10 homeworks](https://ocw.mit.edu/courses/6-172-performance-engineering-of-software-systems-fall-2018/pages/assignments), [4 projects](https://ocw.mit.edu/courses/6-172-performance-engineering-of-software-systems-fall-2018/pages/projects), [4 quizzes](https://ocw.mit.edu/courses/6-172-performance-engineering-of-software-systems-fall-2018/pages/quizzes), and [practice problems](https://ocw.mit.edu/courses/6-172-performance-engineering-of-software-systems-fall-2018/pages/recitation-problems) from selected recitations.
+### MIT 6.106
+
+At MIT, _Performance Engineering of Software Systems_ is an upper-division undergraduate course with prerequisitess of introductory computer architecture, algorithms, and programming courses. Other faculty have adapted this material as an introductory graduate course. The class uses the C language with OpenCilk task-parallel extensions. Materials from Fall 2018 are available on [MIT Open CourseWare](https://ocw.mit.edu/courses/6-172-performance-engineering-of-software-systems-fall-2018/), which includes 23 lectures (listed below), [10 homeworks](https://ocw.mit.edu/courses/6-172-performance-engineering-of-software-systems-fall-2018/pages/assignments), [4 projects](https://ocw.mit.edu/courses/6-172-performance-engineering-of-software-systems-fall-2018/pages/projects), [4 quizzes](https://ocw.mit.edu/courses/6-172-performance-engineering-of-software-systems-fall-2018/pages/quizzes), and [practice problems](https://ocw.mit.edu/courses/6-172-performance-engineering-of-software-systems-fall-2018/pages/recitation-problems) from selected recitations.
 
 #### Lectures
 
@@ -55,6 +61,31 @@ Recent projects have included rotating an image, parallelization of a physical s
 - LaTeX source for homework and projects from a past course offering
 - Reference code for homeworks and projects
 - A library of past quiz and exam questions
+
+### UC Davis EEC 289Q
+
+John Owens adapted the course at MIT to create _Performance Engineering of Software Systems_ at UC Davis.
+
+1. Intro and Matrix Multiplication ([PDF](https://ucdavis.box.com/s/lqbbzplf7cjo1dnxi8hon2pkjigest7n))
+2. Bentley Rules for Optimizing Work ([PDF](https://ucdavis.box.com/s/7asxi08fobekk6e1pkoo5r7zuyjrktrw))
+3. Bit Hacks ([PDF](https://ucdavis.box.com/s/xd10fgi2aslmjiv67q9uajuvh0srfvo8))
+4. Computer Architecture ([PDF](https://ucdavis.box.com/s/itjn1m2cu5czh4qhz5doin4bpbx0f515))
+5. C to Assembly ([PDF](https://ucdavis.box.com/s/n6nvroi4gyk2j0lswcn35eqp81g95bny))
+6. What Compilers Can and Cannot Do ([PDF](https://ucdavis.box.com/s/l9bq9sfkvl6oah88tpzio4hxsvqkmwp7))
+7. Multicore Programming ([PDF](https://ucdavis.box.com/s/hmc5zjo8bnojke8svj5gedyxgveuzh6r))
+8. Races and Parallelism ([PDF](https://ucdavis.box.com/s/h8z91f2t23qhpa976hbt4bnaf972avir))
+9. Analysis of Parallel Algorithms I ([PDF](https://ucdavis.box.com/s/o45xbyoaenzvcww8o0eb4v2o3dg3e9as))
+10. Analysis of Parallel Algorithms II ([PDF](https://ucdavis.box.com/s/etxfwg2l50gqxd40ydk0p8nnpxs9e6z4))
+11. Measurement and Timing ([PDF](https://ucdavis.box.com/s/aplokuj304hzc2qmdbp4w9auo7kb8uct))
+12. Cheetah -- Cilk Runtime ([PDF](https://ucdavis.box.com/s/6eb956s19hair2awfborukl1uk3rsvsz))
+13. Storage Allocation ([PDF](https://ucdavis.box.com/s/eb05vbh9ldem2txtmvbm7ov5r1xpxowz))
+14. Parallel Storage Allocation ([PDF](https://ucdavis.box.com/s/vbpz9zgc3qbbd34808wpjc88y77j9bo5))
+15. Cache-Efficient Algorithms ([PDF](https://ucdavis.box.com/s/11ojllbna5yfdvscm386vg4ne1nr2w17))
+16. Cache-Oblivious Algorithms ([PDF](https://ucdavis.box.com/s/2g6m7ztsj71w34j7m1u4x8dlm29h8x0e))
+17. Nondeterministic Parallel Programming ([PDF](https://ucdavis.box.com/s/8abgpbd67b35d8i2a2piflav2crndszs))
+18. Synchronization without Locks ([PDF](https://ucdavis.box.com/s/dohev283rm0p7iwtlclu849iigdhrrkj))
+19. Potpourri ([PDF](https://ucdavis.box.com/s/a98i1k7c70jg3tw9wdw9kj7xsexbgifx))
+20. Speculative Parallelism ([PDF](https://ucdavis.box.com/s/7px55i4u01kgem0xtq384aenmjm6u23y))
 
 ## Modern algorithms workshop: parallel algorithms
 


### PR DESCRIPTION
Updated teaching-performance page with a new major entry for EEC 289Q, with links to PDFs on Box.

On the same page, also added links from the Modern Algorithms Workshop to PDFs, which are also on Box.

FYI, I configured the PDF links to allow viewing but not downloading, with the intent of encouraging people to contact us for additional access. I don't feel strongly about preventing downloads of PDFs, but wanted to mention this setting here.