### PR TITLE
Fix `__builtin_addressof` typo in reducers.md

### DIFF
--- a/src/doc/reference/reducers.md
+++ b/src/doc/reference/reducers.md
@@ -181,7 +181,7 @@ void compute_sum(long cilk_reducer(zero, add) *sum)
 long provide_reducer()
 {
     long cilk_reducer(zero, add) sum = 0L; // must be initialized
-    compute_sum(__builtin_address(sum));
+    compute_sum(__builtin_addressof(sum));
     return sum;
 }
 ```


### PR DESCRIPTION
Fix typo where `__builtin_address` should be `__builtin_addressof`.  Fixes #236