### PR TITLE
update install page for v3.0

### DIFF
--- a/src/doc/users-guide/install.md
+++ b/src/doc/users-guide/install.md
@@ -22,7 +22,7 @@ download:
 ## System requirements
 
 OpenCilk 3.0 runs on Intel x86 64-bit processors (Haswell and newer), AMD x86
-64-bit processors (Excavator and newer), and various 64-bit ARM processors, including Apple M1 and M2. It has been tested on the following operating systems:
+64-bit processors (Excavator and newer), and various 64-bit ARM processors, including Apple Silicon. It has been tested on the following operating systems:
 
  - Recent versions of Ubuntu, including via the Windows Subsystem for Linux v2 (WSL2) on Windows 10
  - Recent versions of macOS

--- a/src/doc/users-guide/install.md
+++ b/src/doc/users-guide/install.md
@@ -58,7 +58,7 @@ archive for your system, then follow the installation instructions.
 
 Download the appropriate shell archive for your system using one of the following links:
 
-***Linux:***
+***Ubuntu Linux 24.04:***
  - [{{ download.ubuntu_2404_x86.shell }}]({{ download.host }}releases/download/{{ download.release }}/{{ download.ubuntu_2404_x86.shell }})
    ({{ download.ubuntu_2404_x86.size }})
  

--- a/src/doc/users-guide/install.md
+++ b/src/doc/users-guide/install.md
@@ -128,7 +128,7 @@ for your system, then follow the installation instructions.
 
 Download the appropriate tarball for your system using one of the following links:
 
-***Linux:***
+***Ubuntu Linux 24.04:***
  - <a id="{{ download.release }} ubuntu 2204 x86" href="{{ download.host }}releases/download/{{ download.release }}/{{ download.ubuntu_2404_x86.binary }}">{{ download.ubuntu_2404_x86.binary }}</a>
    ({{ download.ubuntu_2404_x86.size }})
  

--- a/src/doc/users-guide/install.md
+++ b/src/doc/users-guide/install.md
@@ -5,31 +5,23 @@ eleventyNavigation:
   order: -3
 download:
   host: https://github.com/OpenCilk/opencilk-project/
-  release: opencilk/v2.1
-  ubuntu_2204_aarch64: 
-    shell: opencilk-2.1.0-aarch64-linux-gnu-ubuntu-22.04.sh
-    binary: opencilk-2.1.0-aarch64-linux-gnu-ubuntu-22.04.tar.gz
-    size: 1.04 GB
-  ubuntu_2204_x86: 
-    shell: opencilk-2.1.0-x86_64-linux-gnu-ubuntu-22.04.sh
-    binary: opencilk-2.1.0-x86_64-linux-gnu-ubuntu-22.04.tar.gz
-    size: 1.07 GB
-  macos_x86: 
-    shell: opencilk-2.1.0-x86_64-apple-darwin21.6.0.sh
-    binary: opencilk-2.1.0-x86_64-apple-darwin21.6.0.tar.gz
-    size: 1.04 GB
+  release: opencilk/v3.0
+  ubuntu_2404_x86: 
+    shell: opencilk-3.0.0-x86_64-linux-gnu-ubuntu-24.04.sh
+    binary: opencilk-3.0.0-x86_64-linux-gnu-ubuntu-24.04.tar.gz
+    size: 1.31 GB
   macos_arm:
-    shell: opencilk-2.1.0-arm64-apple-darwin21.6.0.sh
-    binary: opencilk-2.1.0-arm64-apple-darwin21.6.0.tar.gz
-    size: 979 MB
+    shell: opencilk-3.0.0-arm64-apple-darwin24.3.0.sh
+    binary: opencilk-3.0.0-arm64-apple-darwin24.3.0.tar.gz
+    size: 1.22 GB
   docker: 
-    binary: docker-opencilk-v2.1.tar.gz
-    size: 1.17 GB
+    binary: docker-opencilk-v3.0.tar.gz
+    size: 1.69 GB
 ---
 
 ## System requirements
 
-OpenCilk 2.1 runs on Intel x86 64-bit processors (Haswell and newer), AMD x86
+OpenCilk 3.0 runs on Intel x86 64-bit processors (Haswell and newer), AMD x86
 64-bit processors (Excavator and newer), and various 64-bit ARM processors, including Apple M1 and M2. It has been tested on the following operating systems:
 
  - Recent versions of Ubuntu, including via the Windows Subsystem for Linux v2 (WSL2) on Windows 10
@@ -48,7 +40,7 @@ the necessary system files.
 
 ## Methods of installation
 
-Precompiled binaries for OpenCilk 2.1 can be installed in several ways:
+Precompiled binaries for OpenCilk 3.0 can be installed in several ways:
 - Using a [shell archive (`.sh`)](#installing-using-a-shell-archive) built for the target hardware and operating system.
 - Using a [tarball (`.tar.gz`)](#installing-using-a-tarball) built for the target hardware and operating system.
 - Using a [docker image](#docker-image).
@@ -59,7 +51,7 @@ which precompiled binaries are not available.
 
 ## Installing using a shell archive
 
-To install OpenCilk 2.1 using a shell archive, first download the appropriate shell
+To install OpenCilk 3.0 using a shell archive, first download the appropriate shell
 archive for your system, then follow the installation instructions.
 
 ### Download
@@ -67,23 +59,19 @@ archive for your system, then follow the installation instructions.
 Download the appropriate shell archive for your system using one of the following links:
 
 ***Linux:***
- - [{{ download.ubuntu_2204_aarch64.shell }}]({{ download.host }}releases/download/{{ download.release }}/{{ download.ubuntu_2204_aarch64.shell }})
-   ({{ download.ubuntu_2204_aarch64.size }})
- - [{{ download.ubuntu_2204_x86.shell }}]({{ download.host }}releases/download/{{ download.release }}/{{ download.ubuntu_2204_x86.shell }})
-   ({{ download.ubuntu_2204_x86.size }})
+ - [{{ download.ubuntu_2404_x86.shell }}]({{ download.host }}releases/download/{{ download.release }}/{{ download.ubuntu_2404_x86.shell }})
+   ({{ download.ubuntu_2404_x86.size }})
  
 ***macOS:***
  - [{{ download.macos_arm.shell }}]({{ download.host }}releases/download/{{ download.release }}/{{ download.macos_arm.shell }})
    ({{ download.macos_arm.size }})
- - [{{ download.macos_x86.shell }}]({{ download.host }}releases/download/{{ download.release }}/{{ download.macos_x86.shell }})
-   ({{ download.macos_x86.size }})
 
 ### Install
 
-Execute the shell script to extract OpenCilk 2.1 into the current directory.  For example:
+Execute the shell script to extract OpenCilk 3.0 into the current directory.  For example:
 
 ```shell-session
-$ sh opencilk-2.1.0-x86_64-linux-gnu-ubuntu-22.04.sh
+$ sh opencilk-3.0.0-x86_64-linux-gnu-ubuntu-24.04.sh
 ```
 
 You will be prompted to accept the OpenCilk license and whether or not to
@@ -104,7 +92,7 @@ compilers (e.g., by setting your `PATH` environment variable or installing syste
 {% alert "Note", "<span id='example'>Example:</span>" %}
 
 The following example shows the
-process on Ubuntu 22.04 to install OpenCilk into `/opt/opencilk` without adding
+process on Ubuntu 24.04 to install OpenCilk into `/opt/opencilk` without adding
 a version-specific subdirectory.  The installation and setup process is
 analogous for macOS and other Linux systems.
 
@@ -115,8 +103,8 @@ system.
 
 ```shell-session
 $ mkdir -p /opt/opencilk
-$ sh opencilk-2.1.0-x86_64-linux-gnu-ubuntu-22.04.sh --prefix=/opt/opencilk --exclude-subdir
-OpenCilk Installer Version: 2.1.0, Copyright (c) OpenCilk
+$ sh opencilk-3.0.0-x86_64-linux-gnu-ubuntu-24.04.sh --prefix=/opt/opencilk --exclude-subdir
+OpenCilk Installer Version: 3.0.0, Copyright (c) OpenCilk
 This is a self-extracting archive.
 The archive will be extracted to: /opt/opencilk 
 Using target directory: /opt/opencilk
@@ -133,7 +121,7 @@ system-wide symbolic links.
 
 ## Installing using a tarball
 
-To install OpenCilk 2.1 using a tarball, first download the appropriate tarball
+To install OpenCilk 3.0 using a tarball, first download the appropriate tarball
 for your system, then follow the installation instructions.
 
 ### Download
@@ -141,25 +129,21 @@ for your system, then follow the installation instructions.
 Download the appropriate tarball for your system using one of the following links:
 
 ***Linux:***
- - <a id="{{ download.release }} ubuntu 2204 aarch86" href="{{ download.host }}releases/download/{{ download.release }}/{{ download.ubuntu_2204_aarch64.binary }}">{{ download.ubuntu_2204_aarch64.binary }}</a>
-   ({{ download.ubuntu_2204_aarch64.size }})
- - <a id="{{ download.release }} ubuntu 2204 x86" href="{{ download.host }}releases/download/{{ download.release }}/{{ download.ubuntu_2204_x86.binary }}">{{ download.ubuntu_2204_x86.binary }}</a>
-   ({{ download.ubuntu_2204_x86.size }})
+ - <a id="{{ download.release }} ubuntu 2204 x86" href="{{ download.host }}releases/download/{{ download.release }}/{{ download.ubuntu_2404_x86.binary }}">{{ download.ubuntu_2404_x86.binary }}</a>
+   ({{ download.ubuntu_2404_x86.size }})
  
 ***macOS:***
  - <a id="{{ download.release }} macos arm" href="{{ download.host }}releases/download/{{ download.release }}/{{ download.macos_arm.binary }}">{{ download.macos_arm.binary }}</a>
    ({{ download.macos_arm.size }})
- - <a id="{{ download.release }} macos x86" href="{{ download.host }}releases/download/{{ download.release }}/{{ download.macos_x86.binary }}">{{ download.macos_x86.binary }}</a>
-   ({{ download.macos_x86.size }})
  
 ### Install
 
-Extract OpenCilk 2.1 from the downloaded tarball.  For example:
+Extract OpenCilk 3.0 from the downloaded tarball.  For example:
 ```shell-session
-$ tar xvzf opencilk-2.1.0-x86_64-linux-gnu-ubuntu-22.04.tar.gz
+$ tar xvzf opencilk-3.0.0-x86_64-linux-gnu-ubuntu-24.04.tar.gz
 ```
 will extract the OpenCilk installation into a subdirectory
-`opencilk-2.1.0-x86_64-linux-gnu-ubuntu-22.04/` within the current working directory.
+`opencilk-3.0.0-x86_64-linux-gnu-ubuntu-24.04/` within the current working directory.
 
 {% alert "Note", "Note:" %}
 Extracting the tarball as above is equivalent to running the corresponding
@@ -170,25 +154,25 @@ software license.
 
 ## Docker image
 
-OpenCilk 2.1 is also available as a [docker](https://www.docker.com/) image based on Ubuntu 22.04.
+OpenCilk 3.0 is also available as a [docker](https://www.docker.com/) image based on Ubuntu 24.04.
 You can download the docker image here:
 
 - <a id="{{ download.release }} docker" href="{{ download.host }}releases/download/{{ download.release }}/{{ download.docker.binary }}">{{ download.docker.binary }}</a>
    ({{ download.docker.size }})
 
 The OpenCilk C and C++ compilers are available as `clang` and `clang++` in the
-image.  To use the OpenCilk 2.1 Docker image, download the
-`docker-opencilk-v2.1.tar.gz` file, load the image, and run a container.  For
+image.  To use the OpenCilk 3.0 Docker image, download the
+`docker-opencilk-v3.0.tar.gz` file, load the image, and run a container.  For
 example:
 
 ```shell-session
-$ docker load -i docker-opencilk-v2.1.tar.gz
-$ docker run -it opencilk:v2.1 /bin/bash
+$ docker load -i docker-opencilk-v3.0.tar.gz
+$ docker run -it opencilk:v3.0 /bin/bash
 ```
 
 ## Next steps
 
-The OpenCilk 2.1 installation includes LLVM 16 with the following OpenCilk
+The OpenCilk 3.0 installation includes LLVM 19.1.7 with the following OpenCilk
 components:
 
  - OpenCilk compiler (with the `clang` and `clang++` front-ends)

--- a/src/doc/users-guide/install.md
+++ b/src/doc/users-guide/install.md
@@ -46,7 +46,7 @@ Precompiled binaries for OpenCilk 3.0 can be installed in several ways:
 - Using a [docker image](#docker-image).
 
 You can also [build OpenCilk from source](../build-opencilk-from-source),
-which is the recommended approach for Ubuntu 18.04 and other operating systems for
+which we recommend for operating systems for
 which precompiled binaries are not available.
 
 ## Installing using a shell archive

--- a/src/doc/users-guide/install.md
+++ b/src/doc/users-guide/install.md
@@ -24,7 +24,7 @@ download:
 OpenCilk 3.0 runs on Intel x86 64-bit processors (Haswell and newer), AMD x86
 64-bit processors (Excavator and newer), and various 64-bit ARM processors, including Apple Silicon. It has been tested on the following operating systems:
 
- - Recent versions of Ubuntu, including via the Windows Subsystem for Linux v2 (WSL2) on Windows 10
+ - Recent versions of Ubuntu, including via the Windows Subsystem for Linux v2 (WSL2)
  - Recent versions of macOS
  - FreeBSD 13
  - Recent versions of Fedora


### PR DESCRIPTION
Hi @neboat , I have (belatedly) updated the OpenCilk install page for v3.0. Could you please help confirm this is OK?

Changes include:
* Everything is v3.0, not v2.1
* no more aarch64
* no more macos_x86
* includes LLVM 19, not 16

**Likely loose ends:** I did not (yet) provide a link to [opencilk-3.0.0-x86_64-linux-gnu-ubuntu-24.04.tar.Z](https://github.com/OpenCilk/opencilk-project/releases/download/opencilk%2Fv3.0/opencilk-3.0.0-x86_64-linux-gnu-ubuntu-24.04.tar.Z). I did not (yet) update system requirements. Also, I did not (yet) change the getting started page, even though v3.0 seems to run faster than v2.1, which might invite us to update the examples with better-looking timing info.